### PR TITLE
Use the `BUILD_DOCS` var for conditional documentation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,21 +6,23 @@ set(DOTENV_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
 
 option(BUILD_DOCS "Build documentation" ON)
 
-find_package(Doxygen)
+if(BUILD_DOCS)
+    find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile"
-        @ONLY)
-    add_custom_target(doxygen ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating Doxygen documentation"
-        VERBATIM)
-else(DOXYGEN_FOUND)
-    message("Doxygen needs to be installed to generate documentation")
-endif(DOXYGEN_FOUND)
+    if(DOXYGEN_FOUND)
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile"
+            @ONLY)
+        add_custom_target(doxygen ALL
+            COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating Doxygen documentation"
+            VERBATIM)
+    else(DOXYGEN_FOUND)
+        message("Doxygen needs to be installed to generate documentation")
+    endif(DOXYGEN_FOUND)
+endif(BUILD_DOCS)
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     set(DEFAULT_BUILD_TYPE "Debug")


### PR DESCRIPTION
It seems that `BUILD_DOCS` was not used.