### PR TITLE
Skip empty lines and comment lines

### DIFF
--- a/include/laserpants/dotenv/dotenv.h
+++ b/include/laserpants/dotenv/dotenv.h
@@ -336,6 +336,11 @@ inline void dotenv::do_init(int flags, const char* filename)
 
         while (getline(file, line))
         {
+            const auto len = line.length();
+            if (len == 0 || line[0] == '#')
+                continue;
+            }
+
             const auto pos = line.find("=");
 
             if (pos == std::string::npos) {

--- a/include/laserpants/dotenv/dotenv.h
+++ b/include/laserpants/dotenv/dotenv.h
@@ -337,7 +337,7 @@ inline void dotenv::do_init(int flags, const char* filename)
         while (getline(file, line))
         {
             const auto len = line.length();
-            if (len == 0 || line[0] == '#')
+            if (len == 0 || line[0] == '#') {
                 continue;
             }
 


### PR DESCRIPTION
This adds support for skipping empty lines and lines starting with a `#`, which we regard as comments.

Fixes #9