### PR TITLE
Update CMake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(laserpants_dotenv VERSION 0.9.3 LANGUAGES CXX)
 


### PR DESCRIPTION
cmake 4.0 remove support for versions less than 3.5 and later will remove support for strictly lesser than 3.10