### PR TITLE
Continuous integration, Coverage and Bug fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt install -y build-essential cmake gcc make doxygen lcov gcovr
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }} -DBUILD_TESTS=ON
-          make
+          make -j4
           ctest
           sudo make install
           cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Build and test
         run: |
           sudo apt update
-          sudo apt install -y build-essential cmake gcc make
+          sudo apt install -y build-essential cmake gcc make doxygen
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }}
+          cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }} -DBUILD_TESTS=ON
           make
+          ctest
           sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,16 @@ jobs:
     strategy:
       matrix:
         variant: [Debug, Release]
+
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - name: Build and test
         run: |
-          apt update
-          apt install -y build-essential cmake gcc make
+          sudo apt update
+          sudo apt install -y build-essential cmake gcc make
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }}
           make
-          make install
+          sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,11 @@ jobs:
       - name: Build and test
         run: |
           sudo apt update
-          sudo apt install -y build-essential cmake gcc make doxygen
+          sudo apt install -y build-essential cmake gcc make doxygen lcov gcovr
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }} -DBUILD_TESTS=ON
           make
           ctest
           sudo make install
+          cd ..
+          gcovr --filter='include/' --print-summary --sort-percentage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        variant: [Debug, Release]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test
+        run: |
+          apt update
+          apt install -y build-essential cmake gcc make
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.variant }}
+          make
+          make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(DOTENV_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
 option(BUILD_DOCS "Build documentation" ON)
 option(BUILD_TESTS "Build tests cases" OFF)
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fdump-ipa-inline")
+
 if(BUILD_DOCS)
     find_package(Doxygen)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(laserpants_dotenv VERSION 0.9.3 LANGUAGES CXX)
 set(DOTENV_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
 
 option(BUILD_DOCS "Build documentation" ON)
+option(BUILD_TESTS "Build tests cases" OFF)
 
 if(BUILD_DOCS)
     find_package(Doxygen)
@@ -67,3 +68,25 @@ install(TARGETS dotenv EXPORT dotenv)
 
 install(EXPORT dotenv NAMESPACE laserpants::
     DESTINATION ${DOTENV_CONFIG_INSTALL_DIR})
+
+if (BUILD_TESTS)
+    file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cc")
+
+    include(FetchContent)
+
+    fetchcontent_declare(
+            googletest
+            URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    )
+
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    fetchcontent_makeavailable(googletest)
+
+    enable_testing()
+
+    add_executable(tests ${TESTS})
+    target_link_libraries(tests GTest::gtest_main dotenv)
+
+    include(GoogleTest)
+    gtest_discover_tests(tests)
+endif()

--- a/build/.env.example
+++ b/build/.env.example
@@ -1,0 +1,1 @@
+DEFINED_VAR="OLHE"

--- a/cmake/laserpants_dotenv-config.cmake
+++ b/cmake/laserpants_dotenv-config.cmake
@@ -1,3 +1,3 @@
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-include(${SELF_DIR}/${CMAKE_BUILD_TYPE}/dotenv.cmake)
+include(${SELF_DIR}/dotenv.cmake)

--- a/tests/base_test.cc
+++ b/tests/base_test.cc
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include <dotenv.h>
+
+class BaseTestFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dotenv::init(".env.example");
+    }
+};
+
+TEST_F(BaseTestFixture, ReadUndefinedVariableWithDefaultValue) {
+    const auto _value = dotenv::getenv("UNDEFINED_VAR", "EHLO");
+    ASSERT_EQ(_value, "EHLO");
+}
+
+TEST_F(BaseTestFixture, ReadDefinedVariableWithDefaultValue) {
+    const auto _value = dotenv::getenv("DEFINED_VAR", "EHLO");
+    ASSERT_EQ(_value, "OLHE");
+}
+


### PR DESCRIPTION
Hi @laserpants 

I've been using your package for a while, it works nice but i'm facing an issue:

> When I install your library using cmake, make, and make install, and finally use FindPackage to use it, I get an error... Because it's looking for the "dotenv.cmake" file in a folder that doesn't exist.

To put it in simple terms:

```
include(${SELF_DIR}/${CMAKE_BUILD_TYPE}/dotenv.cmake)
```

This line assumes that dotenv.cmake is located in Debug/dotenv.cmake or Release/dotenv.cmake.

But look at the last part of this build log:

```
➜  dotenv-cpp git:(master) ✗ sudo make install
[sudo] contraseña para ian: 
[100%] Generating Doxygen documentation
...
[100%] Built target doxygen
Install the project...
-- Install configuration: "Debug"
-- Installing: /usr/local/include/laserpants/dotenv-0.9.3/laserpants_dotenv-config.h
-- Installing: /usr/local/include/laserpants/dotenv-0.9.3/dotenv.h
-- Installing: /usr/local/lib/cmake/laserpants_dotenv/laserpants_dotenv-config.cmake
-- Installing: /usr/local/lib/cmake/laserpants_dotenv/dotenv.cmake
```

> Take note about where is dotenv.cmake ...

So, by adding FindPackage(laserpants_dotenv REQUIRED) ... the next happens ...

```
CMake Error at /usr/local/lib/cmake/laserpants_dotenv/laserpants_dotenv-config.cmake:3 (include):
  include could not find requested file:

    /usr/local/lib/cmake/laserpants_dotenv/Debug/dotenv.cmake
Call Stack (most recent call first):
  CMakeLists.txt:50 (find_package)
```

By the way, not everything is wrong or bad. This PR will provide you:

- Continuous integration.
- Unit testing.
- Coverage.
- Fix of the described bug.

Take your time ... GLHF

Of course, you should have to enable de Github actions ...
