### PR TITLE
Variable 'errcode' can be reduced [variableScope]

### DIFF
--- a/include/laserpants/dotenv/dotenv.h
+++ b/include/laserpants/dotenv/dotenv.h
@@ -168,10 +168,9 @@ inline std::string dotenv::getenv(const char* name, const std::string& def)
 // https://stackoverflow.com/questions/17258029/c-setenv-undefined-identifier-in-visual-studio
 inline int setenv(const char *name, const char *value, int overwrite)
 {
-    int errcode = 0;
-
     if (!overwrite)
     {
+        int errcode = 0;
         size_t envsize = 0;
         errcode = getenv_s(&envsize, NULL, 0, name);
         if (errcode || envsize) return errcode;


### PR DESCRIPTION
Fixing: `style: The scope of the variable 'errcode' can be reduced. [variableScope]` cpp check..

(and since I use Linux, this also solves the second cpp check error I have: `style: Variable 'errcode' is assigned a value that is never used. [unreadVariable]`). Both are solved by this single PR.